### PR TITLE
Rerender feedstock to add Python 3.6 builds

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+* text=auto
+
+meta.yaml text eol=lf
+build.sh text eol=lf
+bld.bat text eol=crlf

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,14 +4,14 @@
 language: generic
 
 os: osx
-osx_image: beta-xcode6.1
+osx_image: xcode6.4
 
 env:
   matrix:
     
     - CONDA_PY=27
-    - CONDA_PY=34
     - CONDA_PY=35
+    - CONDA_PY=36
   global:
     # The BINSTAR_TOKEN secure variable. This is defined canonically in conda-forge.yml.
     - secure: "SXjRN61Tsy6/mMtZWRX91OFY5pD/8s5mCfJ0Bo3GgDH0ITeHULdxTKt1Gy5KMjM0ikrBYv4ZLn6/S1afjVyoPQyvteuMpkI9fTyIlR+MRpZldvV9Q/K3mJ2ws1EEF+LlueFbueVCVcZzUphxvPsjmBJI00aFrW/pTO1H4sACv/N7KN9hOtb+9lyvynVM77pNB7QDKQgZER3Vw9BorBXqHY6mE5xEEE/G9jH4bXa4VTwn8YxGPqPMwRbHTaEbrThOQClqedLp9iS0T5zov5gYh0+UJYC0frmQyRc2FG2GbWO3DmzePgxJfvSnjQB09DfDWgu+RqvHwGSd7LmPwjI9ZpLU3YJxxEauyHlVKzCMq9ZuUUvdsRu3akp9LWWIYKKwAl/vkHX79RGlOfbQj/8Ch39wW1PURwqv2Ntlz78hUWsetDBvVLN5Ea+LvSFghY4DSOUg8DvtScDp2R92Gx/FsEYiqjGi0ahcWlmwF4mU80W33NTg+sLq4FBYeOyJLHt8kzw0gHwphUYA4leDcbgB0ucZPNYMRA5816xhQC/0J6PGLTl+M/9wsSFflRQSG/KyK4il4ZCxlCDCkGmCbby1sUQxeBjYPjePvUpRoukibE7yCiFmmvHaRsjiCt2vDtX1F+WsNA7dXcKeUdjWbmAH6V8CRolrF0s7xK7foOvgpl4="
@@ -19,18 +19,32 @@ env:
 
 before_install:
     # Remove homebrew.
-    - brew remove --force $(brew list)
-    - brew cleanup -s
-    - rm -rf $(brew --cache)
+    - |
+      echo ""
+      echo "Removing homebrew from Travis CI to avoid conflicts."
+      curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/uninstall > ~/uninstall_homebrew
+      chmod +x ~/uninstall_homebrew
+      ~/uninstall_homebrew -fq
+      rm ~/uninstall_homebrew
+
 
 install:
+    # Install Miniconda.
     - |
+      echo ""
+      echo "Installing a fresh version of Miniconda."
       MINICONDA_URL="https://repo.continuum.io/miniconda"
       MINICONDA_FILE="Miniconda3-latest-MacOSX-x86_64.sh"
       curl -L -O "${MINICONDA_URL}/${MINICONDA_FILE}"
       bash $MINICONDA_FILE -b
 
+    # Configure conda.
+    - |
+      echo ""
+      echo "Configuring conda."
       source /Users/travis/miniconda3/bin/activate root
+      conda config --remove channels defaults
+      conda config --add channels defaults
       conda config --add channels conda-forge
       conda config --set show_channel_urls true
       conda install --yes --quiet conda-forge-build-setup

--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,5 @@
 BSD 3-clause license
-Copyright (c) conda-forge
+Copyright (c) 2015-2017, conda-forge
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:

--- a/README.md
+++ b/README.md
@@ -11,6 +11,18 @@ Summary: 3D viewers for Glue
 
 
 
+Current build status
+====================
+
+Linux: [![Circle CI](https://circleci.com/gh/conda-forge/glue-vispy-viewers-feedstock.svg?style=shield)](https://circleci.com/gh/conda-forge/glue-vispy-viewers-feedstock)
+OSX: [![TravisCI](https://travis-ci.org/conda-forge/glue-vispy-viewers-feedstock.svg?branch=master)](https://travis-ci.org/conda-forge/glue-vispy-viewers-feedstock)
+Windows: [![AppVeyor](https://ci.appveyor.com/api/projects/status/github/conda-forge/glue-vispy-viewers-feedstock?svg=True)](https://ci.appveyor.com/project/conda-forge/glue-vispy-viewers-feedstock/branch/master)
+
+Current release info
+====================
+Version: [![Anaconda-Server Badge](https://anaconda.org/conda-forge/glue-vispy-viewers/badges/version.svg)](https://anaconda.org/conda-forge/glue-vispy-viewers)
+Downloads: [![Anaconda-Server Badge](https://anaconda.org/conda-forge/glue-vispy-viewers/badges/downloads.svg)](https://anaconda.org/conda-forge/glue-vispy-viewers)
+
 Installing glue-vispy-viewers
 =============================
 
@@ -66,18 +78,6 @@ Terminology
 
 **conda-forge** - the place where the feedstock and smithy live and work to
                   produce the finished article (built conda distributions)
-
-Current build status
-====================
-
-Linux: [![Circle CI](https://circleci.com/gh/conda-forge/glue-vispy-viewers-feedstock.svg?style=shield)](https://circleci.com/gh/conda-forge/glue-vispy-viewers-feedstock)
-OSX: [![TravisCI](https://travis-ci.org/conda-forge/glue-vispy-viewers-feedstock.svg?branch=master)](https://travis-ci.org/conda-forge/glue-vispy-viewers-feedstock)
-Windows: [![AppVeyor](https://ci.appveyor.com/api/projects/status/github/conda-forge/glue-vispy-viewers-feedstock?svg=True)](https://ci.appveyor.com/project/conda-forge/glue-vispy-viewers-feedstock/branch/master)
-
-Current release info
-====================
-Version: [![Anaconda-Server Badge](https://anaconda.org/conda-forge/glue-vispy-viewers/badges/version.svg)](https://anaconda.org/conda-forge/glue-vispy-viewers)
-Downloads: [![Anaconda-Server Badge](https://anaconda.org/conda-forge/glue-vispy-viewers/badges/downloads.svg)](https://anaconda.org/conda-forge/glue-vispy-viewers)
 
 
 Updating glue-vispy-viewers-feedstock

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,11 +9,6 @@ environment:
   # See: http://stackoverflow.com/a/13751649/163740
   CMD_IN_ENV: "cmd /E:ON /V:ON /C obvci_appveyor_python_build_env.cmd"
 
-  # We set a default Python version for the miniconda that is to be installed. This can be
-  # overridden in the matrix definition where appropriate.
-  CONDA_PY: "27"
-  CONDA_INSTALL_LOCN: "C:\\Miniconda-x64"
-
   BINSTAR_TOKEN:
     # The BINSTAR_TOKEN secure variable. This is defined canonically in conda-forge.yml.
     secure: MP4hZYylDyUWEsrt3u3cod2sbFeRwUziH02mvQOdbjsTO/l1yIxDkP/76rSIjcGC
@@ -28,19 +23,19 @@ environment:
       CONDA_INSTALL_LOCN: C:\\Miniconda-x64
 
     - TARGET_ARCH: x86
-      CONDA_PY: 34
-      CONDA_INSTALL_LOCN: C:\\Miniconda3
-
-    - TARGET_ARCH: x64
-      CONDA_PY: 34
-      CONDA_INSTALL_LOCN: C:\\Miniconda3-x64
-
-    - TARGET_ARCH: x86
       CONDA_PY: 35
       CONDA_INSTALL_LOCN: C:\\Miniconda35
 
     - TARGET_ARCH: x64
       CONDA_PY: 35
+      CONDA_INSTALL_LOCN: C:\\Miniconda35-x64
+
+    - TARGET_ARCH: x86
+      CONDA_PY: 36
+      CONDA_INSTALL_LOCN: C:\\Miniconda35
+
+    - TARGET_ARCH: x64
+      CONDA_PY: 36
       CONDA_INSTALL_LOCN: C:\\Miniconda35-x64
 
 
@@ -63,23 +58,19 @@ install:
     # Cywing's git breaks conda-build. (See https://github.com/conda-forge/conda-smithy-feedstock/pull/2.)
     - cmd: rmdir C:\cygwin /s /q
 
-    # Add our channels.
-    - cmd: set "OLDPATH=%PATH%"
-    - cmd: set "PATH=%CONDA_INSTALL_LOCN%\\Scripts;%CONDA_INSTALL_LOCN%\\Library\\bin;%PATH%"
-    - cmd: conda config --set show_channel_urls true
-    - cmd: conda config --add channels conda-forge
-
-    # Add a hack to switch to `conda` version `4.1.12` before activating.
-    # This is required to handle a long path activation issue.
-    # Please see PR ( https://github.com/conda/conda/pull/3349 ).
-    - cmd: conda install --yes --quiet conda=4.1.12
-    - cmd: set "PATH=%OLDPATH%"
-    - cmd: set "OLDPATH="
-
-    # Actually activate `conda`.
+    # Add path, activate `conda` and update conda.
     - cmd: call %CONDA_INSTALL_LOCN%\Scripts\activate.bat
+    - cmd: conda update --yes --quiet conda
+
     - cmd: set PYTHONUNBUFFERED=1
 
+    # Add our channels.
+    - cmd: conda config --set show_channel_urls true
+    - cmd: conda config --remove channels defaults
+    - cmd: conda config --add channels defaults
+    - cmd: conda config --add channels conda-forge
+
+    # Configure the VM.
     - cmd: conda install -n root --quiet --yes obvious-ci
     - cmd: conda install -n root --quiet --yes conda-forge-build-setup
     - cmd: run_conda_forge_build_setup

--- a/ci_support/run_docker_build.sh
+++ b/ci_support/run_docker_build.sh
@@ -14,7 +14,7 @@ config=$(cat <<CONDARC
 
 channels:
  - conda-forge
- - defaults # As we need conda-build
+ - defaults
 
 conda-build:
  root-dir: /feedstock_root/build_artefacts
@@ -25,8 +25,8 @@ CONDARC
 )
 
 cat << EOF | docker run -i \
-                        -v ${RECIPE_ROOT}:/recipe_root \
-                        -v ${FEEDSTOCK_ROOT}:/feedstock_root \
+                        -v "${RECIPE_ROOT}":/recipe_root \
+                        -v "${FEEDSTOCK_ROOT}":/feedstock_root \
                         -a stdin -a stdout -a stderr \
                         condaforge/linux-anvil \
                         bash || exit $?
@@ -49,13 +49,13 @@ source run_conda_forge_build_setup
     upload_or_check_non_existence /recipe_root conda-forge --channel=main || exit 1
 
     set -x
-    export CONDA_PY=34
+    export CONDA_PY=35
     set +x
     conda build /recipe_root --quiet || exit 1
     upload_or_check_non_existence /recipe_root conda-forge --channel=main || exit 1
 
     set -x
-    export CONDA_PY=35
+    export CONDA_PY=36
     set +x
     conda build /recipe_root --quiet || exit 1
     upload_or_check_non_existence /recipe_root conda-forge --channel=main || exit 1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   md5: 07b0ec9fec510352edc617e95ee86469
 
 build:
-  number: 0
+  number: 1
   script: python setup.py install --single-version-externally-managed --record record.txt
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,7 +23,7 @@ requirements:
     - python
     - numpy
     - pyopengl
-    - glueviz >=0.9
+    - glueviz >=0.9  # [not py36]
     - scikit-image
     - matplotlib
     - qtpy
@@ -31,9 +31,9 @@ requirements:
 
 test:
   imports:
-    - glue_vispy_viewers
-    - glue_vispy_viewers.scatter
-    - glue_vispy_viewers.volume
+    - glue_vispy_viewers  # [not py36]
+    - glue_vispy_viewers.scatter  # [not py36]
+    - glue_vispy_viewers.volume  # [not py36]
 
 about:
   home: https://github.com/glue-viz/glue-vispy-viewers


### PR DESCRIPTION
This includes temporarily removing the glueviz dependency and disabling tests with Python 3.6. I will re-enable these once this has been merged and glueviz also has a Python 3.6 build (circular dependency fun!)